### PR TITLE
Improve: adding mongodb service to docker-compose

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -4,13 +4,22 @@ services:
     build:
       context: .
       dockerfile: ./docker/Dockerfile
+      args:
+        - ENV_FILE=.env.local
     image: namviek
     env_file:
       - .env.local
     ports:
       - '3333:3333'
     command: /bin/sh -c "./docker/entrypoints.sh && yarn backend"
+    healthcheck:
+      test: curl --fail http://localhost:3333 || exit 1
+      interval: 30s
+      timeout: 10s
+      retries: 5
+      start_period: 30s
     depends_on:
+      - mongodb
       - redis
     networks:
       - namviek-network
@@ -35,6 +44,33 @@ services:
       - '6379:6379'
     networks:
       - namviek-network
+
+  mongodb:
+    container_name: mongodb
+    image: 'mongo:latest'
+    command: ["--replSet", "rs0", "--bind_ip_all", "--port", "27017"]
+    ports:
+      - '27017:27017'
+    extra_hosts:
+      - "host.docker.internal:host-gateway"
+    healthcheck:
+      test: echo "try { rs.status() } catch (err) { rs.initiate({_id:'rs0',members:[{_id:0,host:'host.docker.internal:27017'}]}) }" | mongosh --port 27017 --quiet
+      interval: 5s
+      timeout: 30s
+      start_period: 0s
+      start_interval: 1s
+      retries: 30
+    environment:
+      MONGO_INITDB_DATABASE: namviek
+    volumes:
+      - mongodb-data:/data/db
+      - mongodb-config:/data/configdb
+    networks:
+      - namviek-network
+
+volumes:
+  mongodb-data:
+  mongodb-config:
 
 networks:
   namviek-network:

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -28,8 +28,11 @@ RUN addgroup -S namviek && \
 
 WORKDIR /app
 
-# Copy .env.local file
-COPY .env.local .env
+# Argument to select the env file
+ARG ENV_FILE=.env.local
+
+# Copy the env file
+COPY ${ENV_FILE} .env
 
 #grab previously installed modules without caches. 
 COPY --from=builder /app/node_modules ./node_modules


### PR DESCRIPTION
Adding the mongodb service to the compose, additionally add an ENV_FILE ARG in the Dockerfile, in case we later have a compose for development and another for production.

---

REF: #190 